### PR TITLE
use secrets instead of inputs

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,15 +4,6 @@ name: Plugin publish
 # https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow
 on:
   workflow_dispatch:
-    inputs:
-      gradle_org_publication_key:
-        description: 'Api Key from Gradle.Org used for plugin publication. See https://docs.gradle.org/current/userguide/publishing_gradle_plugins.html#publish_your_plugin_to_the_plugin_portal'
-        required: true
-        type: string
-      gradle_org_publication_secret:
-        description: 'Secret Key from Gradle.Org used for plugin publication. See https://docs.gradle.org/current/userguide/publishing_gradle_plugins.html#publish_your_plugin_to_the_plugin_portal'
-        required: true
-        type: string
 
 permissions:
   contents: read
@@ -51,4 +42,6 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           gradle-home-cache-cleanup: true
-          arguments: publishPlugins -Pgradle.publish.key=${{ inputs.gradle_org_publication_key }} -Pgradle.publish.secret=${{ inputs.gradle_org_publication_secret }} --stacktrace
+          # Secrets are uploaded via https://docs.github.com/en/actions/security-guides/encrypted-secrets
+          # Correct them on https://github.com/Citi/gradle-helm-plugin/settings/secrets/actions
+          arguments: publishPlugins -Pgradle.publish.key=${{ secrets.GRADLE_PUBLISH_KEY }} -Pgradle.publish.secret=${{ secrets.GRADLE_PUBLISH_SECRET }} --stacktrace


### PR DESCRIPTION
Gradle publish secrets should use credentials (which is more secure), instead of inputs.