### PR TITLE
add helm plugin description

### DIFF
--- a/helm-plugin/build.gradle.kts
+++ b/helm-plugin/build.gradle.kts
@@ -34,11 +34,13 @@ gradlePlugin {
             id = "com.citi.helm-commands"
             displayName = "Helm Commands plugin"
             implementationClass = "com.citi.gradle.plugins.helm.command.HelmCommandsPlugin"
+            description = "Wrapper for common helm commands"
         }
         create("helmPlugin") {
             id = "com.citi.helm"
             displayName = "Helm plugin"
             implementationClass = "com.citi.gradle.plugins.helm.HelmPlugin"
+            description = "Gradle plugin to help preparing Helm Charts. Supports charts packaging, linting, dependencies update, etc."
         }
     }
 }

--- a/helm-publish-plugin/build.gradle.kts
+++ b/helm-publish-plugin/build.gradle.kts
@@ -38,6 +38,7 @@ gradlePlugin {
         create("helmPublishPlugin") {
             id = "com.citi.helm-publish"
             implementationClass = "com.citi.gradle.plugins.helm.publishing.HelmPublishPlugin"
+            description = "Extension for Gradle Helm Plugin. Allows helm chart publishing. Helm doesn't have this feature, so different publications are used for different helm repository providers"
         }
     }
 }

--- a/helm-releases-plugin/build.gradle.kts
+++ b/helm-releases-plugin/build.gradle.kts
@@ -24,6 +24,7 @@ gradlePlugin {
             id = "com.citi.helm-releases"
             displayName = "Helm Releases Plugin"
             implementationClass = "com.citi.gradle.plugins.helm.release.HelmReleasesPlugin"
+            description = "Extension for Gradle Helm Plugin. Supports charts installation/uninstallation."
         }
     }
 }


### PR DESCRIPTION
Publication was failed, because of:
```
Caused by: java.lang.IllegalArgumentException: Plugin 'helmCommandsPlugin' has no 'description' property set
	at com.gradle.publish.AbstractConfigValidator.validateProperty(AbstractConfigValidator.java:137)
	at com.gradle.publish.AbstractConfigValidator.validateDescription(AbstractConfigValidator.java:128)
	at com.gradle.publish.ConfigValidator.validatePluginConfig(ConfigValidator.java:34)
	at com.gradle.publish.ConfigValidator.validateConfig(ConfigValidator.java:25)
```