### PR TITLE
Configure documentation upload

### DIFF
--- a/.github/workflows/publish-documentation.yaml
+++ b/.github/workflows/publish-documentation.yaml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: read
   pages: write
+  id-token: write
 
 jobs:
   gradle:

--- a/.github/workflows/publish-documentation.yaml
+++ b/.github/workflows/publish-documentation.yaml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  pages: write
 
 jobs:
   gradle:

--- a/.github/workflows/publish-documentation.yaml
+++ b/.github/workflows/publish-documentation.yaml
@@ -40,7 +40,7 @@ jobs:
 
       # https://github.com/actions/upload-pages-artifact
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: './build/docs/asciidoc'
 


### PR DESCRIPTION
Goal: start uploading the documentation. Current process is fully manual: we must run a custom workflow after the release (at least until #24).

Current documentation is here: https://citi.github.io/gradle-helm-plugin/ (project files haven't been updated, that will be done in a separate PR).