### PR TITLE
Create dependency-review.yml

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -20,4 +20,3 @@ jobs:
           fail-on-severity: high
           allow-licenses: MIT, Apache-2.0, BSD-3-Clause, ISC, BSD-2-Clause, Unlicense, CC0-1.0, 0BSD, X11, MPL-2.0, MPL-1.0, MPL-1.1, MPL-2.0
           fail-on-scopes: development, runtime
-          allow-dependencies-licenses: 'pkg:npm/caniuse-lite'

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,23 @@
+name: Dependency Review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          comment-summary-in-pr: always
+          fail-on-severity: high
+          allow-licenses: MIT, Apache-2.0, BSD-3-Clause, ISC, BSD-2-Clause, Unlicense, CC0-1.0, 0BSD, X11, MPL-2.0, MPL-1.0, MPL-1.1, MPL-2.0
+          fail-on-scopes: development, runtime
+          allow-dependencies-licenses: 'pkg:npm/caniuse-lite'

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -18,5 +18,5 @@ jobs:
         with:
           comment-summary-in-pr: always
           fail-on-severity: high
-          allow-licenses: MIT, Apache-2.0, BSD-3-Clause, ISC, BSD-2-Clause, Unlicense, CC0-1.0, 0BSD, X11, MPL-2.0, MPL-1.0, MPL-1.1, MPL-2.0
+          allow-licenses: MIT
           fail-on-scopes: development, runtime


### PR DESCRIPTION
This change addresses the issue reported in [Issue #33](https://github.com/Citi/gradle-helm-plugin/issues/33).

## Changes Made
- Added a new GitHub Actions workflow file (`dependency-review.yml`) to the `.github/workflows` directory.
- Configured the workflow to run the Dependency Review Action on every pull request.
- Configured permissions required by the action.
- Specified job to run on the `ubuntu-latest` environment.
- Configured the Dependency Review Action to:
  - Post a summary comment in the pull request.
  - Fail the CI if vulnerabilities with a severity of "high" are found.
  - Specify allowed licenses.
  - Specify which dependency scopes should cause the CI to fail if vulnerabilities are found.
  - Allow specific licenses for certain dependencies.