### PR TITLE
Update dependency-review.yml

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -16,5 +16,5 @@ jobs:
         with:
           comment-summary-in-pr: always
           fail-on-severity: high
-          allow-licenses: MIT
+          allow-licenses: MIT, Apache-2.0
           fail-on-scopes: development, runtime


### PR DESCRIPTION
Adds `Apache-2.0` license to Dependency Review Action allow list 👍 