### PR TITLE
Group Kotlin and Detekt updates in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,15 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "groupName": "Kotlin and Detekt",
+      "matchPackagePatterns": [
+        "org.jetbrains.kotlin",
+        "io.gitlab.arturbosch.detekt"
+      ],
+      "matchManagers": ["gradle"]
+    }
   ]
 }


### PR DESCRIPTION
This PR adds a Renovate dependency update group for Kotlin and Detekt so that they are always upgraded together (this avoids the version skew issue where Detekt is compiled against a different Kotlin version, which can break builds after an automatic update).

There are no code changes in the plugin itself, just an update to renovate.json. I verified that ./gradlew check still passes after the change.

Resolves #50
