### PR TITLE
Publish checksum data to artifactory and allow uploading charts to custom path in artifactory

### DIFF
--- a/docs/publishing-charts.adoc
+++ b/docs/publishing-charts.adoc
@@ -102,6 +102,8 @@ helm {
         repositories {
             artifactory {
                 url = uri('http://artifactory.example.com/helm-local')
+                // uploadPath is optional and defaults to '/{chartName}-{chartVersion}.tgz'
+                uploadPath = '/charts/{name}/{version}/{filename}'
             }
         }
     }
@@ -116,11 +118,19 @@ helm {
         repositories {
             artifactory {
                 url.set(uri("http://artifactory.example.com/helm-local"))
+                // uploadPath is optional and defaults to '/{chartName}-{chartVersion}.tgz'
+                uploadPath.set("/charts/{name}/{version}/{filename}")
             }
         }
     }
 }
 ----
+
+The following placeholders can be used in the `uploadPath` property:
+
+- `{name}` will be replaced with the chart name
+- `{version}` will be replaced with the chart version
+- `{filename}` will be replaced with the file name of the packaged chart, i.e. `{name}-{version}.tgz`
 
 == Repository Types
 

--- a/helm-publish-plugin/api/helm-publish-plugin.api
+++ b/helm-publish-plugin/api/helm-publish-plugin.api
@@ -9,6 +9,7 @@ public final class com/citi/gradle/plugins/helm/publishing/HelmPublishPluginCons
 }
 
 public abstract interface class com/citi/gradle/plugins/helm/publishing/dsl/ArtifactoryHelmPublishingRepository : com/citi/gradle/plugins/helm/publishing/dsl/HelmPublishingRepository {
+	public abstract fun getUploadPath ()Lorg/gradle/api/provider/Property;
 }
 
 public final class com/citi/gradle/plugins/helm/publishing/dsl/ArtifactoryHelmPublishingRepository$DefaultImpls {

--- a/helm-publish-plugin/src/main/kotlin/com/citi/gradle/plugins/helm/publishing/dsl/ArtifactoryHelmPublishingRepository.kt
+++ b/helm-publish-plugin/src/main/kotlin/com/citi/gradle/plugins/helm/publishing/dsl/ArtifactoryHelmPublishingRepository.kt
@@ -1,18 +1,34 @@
 package com.citi.gradle.plugins.helm.publishing.dsl
 
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
 import com.citi.gradle.plugins.helm.dsl.credentials.internal.SerializableCredentials
 import com.citi.gradle.plugins.helm.dsl.credentials.internal.toSerializable
 import com.citi.gradle.plugins.helm.publishing.publishers.AbstractHttpHelmChartPublisher
 import com.citi.gradle.plugins.helm.publishing.publishers.HelmChartPublisher
 import com.citi.gradle.plugins.helm.publishing.publishers.PublisherParams
 import com.citi.gradle.plugins.helm.util.calculateDigestHex
+import org.unbrokendome.gradle.pluginutils.property
 import java.io.File
 import java.net.URI
 import javax.inject.Inject
 
 
-interface ArtifactoryHelmPublishingRepository : HelmPublishingRepository
+interface ArtifactoryHelmPublishingRepository : HelmPublishingRepository {
+
+    /**
+     * The path, relative to the base [url], where the chart packages will be uploaded.
+     *
+     * May contain the following placeholders:
+     *
+     * - `{name}` will be replaced with the chart name
+     * - `{version}` will be replaced with the chart version
+     * - `{filename}` will be replaced with the filename of the packaged chart, i.e. `{name}-{version}.tgz`
+     *
+     * Defaults to `/{name}-{version}.tgz`.
+     */
+    val uploadPath: Property<String>
+}
 
 
 private open class DefaultArtifactoryHelmPublishingRepository
@@ -24,23 +40,29 @@ private open class DefaultArtifactoryHelmPublishingRepository
     override val publisherParams: PublisherParams
         get() = ArtifactoryPublisherParams(
             url = url.get(),
-            credentials = configuredCredentials.orNull?.toSerializable()
+            credentials = configuredCredentials.orNull?.toSerializable(),
+            uploadPath = uploadPath.get()
         )
 
+    override val uploadPath: Property<String> =
+        objects.property<String>()
+            .convention("/{name}-{version}.tgz")
 
     private class ArtifactoryPublisherParams(
         private val url: URI,
-        private val credentials: SerializableCredentials?
+        private val credentials: SerializableCredentials?,
+        private val uploadPath: String
     ) : PublisherParams {
 
         override fun createPublisher(): HelmChartPublisher =
-            ArtifactoryPublisher(url, credentials)
+            ArtifactoryPublisher(url, credentials, uploadPath)
     }
 
 
     private class ArtifactoryPublisher(
         url: URI,
-        credentials: SerializableCredentials?
+        credentials: SerializableCredentials?,
+        private val uploadPath: String
     ) : AbstractHttpHelmChartPublisher(url, credentials) {
 
         override val uploadMethod: String
@@ -48,7 +70,10 @@ private open class DefaultArtifactoryHelmPublishingRepository
 
 
         override fun uploadPath(chartName: String, chartVersion: String): String =
-            "/$chartName-$chartVersion.tgz"
+            this.uploadPath
+                .replace("{name}", chartName)
+                .replace("{version}", chartVersion)
+                .replace("{filename}", "$chartName-$chartVersion.tgz")
 
 
         override fun additionalHeaders(chartName: String, chartVersion: String, chartFile: File): Map<String, String> =

--- a/helm-publish-plugin/src/main/kotlin/com/citi/gradle/plugins/helm/publishing/publishers/AbstractHttpHelmChartPublisher.kt
+++ b/helm-publish-plugin/src/main/kotlin/com/citi/gradle/plugins/helm/publishing/publishers/AbstractHttpHelmChartPublisher.kt
@@ -15,6 +15,7 @@ import org.slf4j.LoggerFactory
 import com.citi.gradle.plugins.helm.dsl.credentials.internal.SerializableCertificateCredentials
 import com.citi.gradle.plugins.helm.dsl.credentials.internal.SerializableCredentials
 import com.citi.gradle.plugins.helm.dsl.credentials.internal.SerializablePasswordCredentials
+import okhttp3.Headers.Companion.toHeaders
 import java.io.File
 import java.net.URI
 
@@ -75,6 +76,7 @@ internal abstract class AbstractHttpHelmChartPublisher(
 
         val request = Request.Builder().run {
             url(uploadUrl.toHttpUrl())
+            headers(additionalHeaders(chartName, chartVersion, chartFile).toHeaders())
             method(uploadMethod, requestBody(chartFile))
             build()
         }


### PR DESCRIPTION
Recently we started using this plugin. We publish the helm charts to the Jfrog artifactory.

I noticed 2 issues:
- When a chart is published the checksum data in the request headers is not sent in the http request to artifactory.
- Since artifactory allows helm chart to be placed at any path in a repository, it would be cool to override the default path.

With this PR, I have addressed both and manually tested the changes done with artifactory.

Please review and let me know if there are any comments.